### PR TITLE
New Feature Rdy for Deploying 

### DIFF
--- a/frontend/src/components/GameDetail.tsx
+++ b/frontend/src/components/GameDetail.tsx
@@ -23,11 +23,18 @@ export default function GameDetails(props: GameDetailProps) {
                 <Card sx={{bgcolor: "transparent", boxShadow: "none"}}>
                     <CardHeader title={game.title} sx={{fontWeight: "bold", color: "lightBlue"}}/>
                     <CardContent>
-                        <Box sx={{ display: "flex", justifyContent: "center", flexDirection: "row", alignItems: "center", gap: 5, marginBottom: '16px' }}>
+                        <Box sx={{
+                            display: "flex",
+                            justifyContent: "center",
+                            flexDirection: "row",
+                            alignItems: "center",
+                            gap: 5,
+                            marginBottom: '16px'
+                        }}>
                             <Box>
                                 <Typography variant="body1"
                                             color="text.secondary"
-                                            sx={{ fontWeight: "bold", color: "snow" }}>
+                                            sx={{fontWeight: "bold", color: "snow"}}>
                                     Genre
                                 </Typography>
                                 <Typography variant="body1"
@@ -39,7 +46,7 @@ export default function GameDetails(props: GameDetailProps) {
                             <Box>
                                 <Typography variant="body1"
                                             color="text.secondary"
-                                            sx={{ fontWeight: "bold", color: "snow"  }}>
+                                            sx={{fontWeight: "bold", color: "snow"}}>
                                     Publisher
                                 </Typography>
                                 <Typography variant="body1"
@@ -51,11 +58,28 @@ export default function GameDetails(props: GameDetailProps) {
                         </Box>
                         <img src={game.imageUrl}
                              alt="Ohne Bild"
-                             style={{ objectFit: 'cover', maxWidth: '700px', maxHeight: '700px', width: '100%', height: '100%' }}/>
-                        <Typography variant="body2" color="text.secondary"
-                                    sx={{marginTop: 2, paddingBottom: 2, maxWidth: 600, mx: "auto", color: "snow" }}>
+                             style={{
+                                 objectFit: 'cover',
+                                 maxWidth: '700px',
+                                 maxHeight: '700px',
+                                 width: '100%',
+                                 height: '100%'
+                             }}/>
+                        <Typography
+                            variant="body2"
+                            color="text.secondary"
+                            sx={{
+                                marginTop: 2,
+                                paddingBottom: 2,
+                                maxWidth: 600,
+                                mx: "auto",
+                                color: "snow",
+                                whiteSpace: 'pre-line', // Zeilenumbrüche anzeigen
+                            }}
+                        >
                             {game.note}
                         </Typography>
+
                         {editing ? (
                             <form onSubmit={handleFormSubmit}>
                                 <Box sx={{

--- a/frontend/src/components/GameDetail.tsx
+++ b/frontend/src/components/GameDetail.tsx
@@ -37,9 +37,15 @@ export default function GameDetails(props: GameDetailProps) {
                                             sx={{fontWeight: "bold", color: "snow"}}>
                                     Genre
                                 </Typography>
-                                <Typography variant="body1"
+                                <Typography variant="body2"
                                             color="text.secondary"
-                                            sx={{color: "snow"}}>
+                                            sx={{
+                                                color: "snow",
+                                                maxWidth: 250,
+                                                whiteSpace: 'nowrap', // Limit text to one line
+                                                overflow: 'hidden',   // Cut off text if too long
+                                                textOverflow: 'ellipsis', // ... Show when text is truncated
+                                            }}>
                                     {game.genre}
                                 </Typography>
                             </Box>
@@ -49,9 +55,15 @@ export default function GameDetails(props: GameDetailProps) {
                                             sx={{fontWeight: "bold", color: "snow"}}>
                                     Publisher
                                 </Typography>
-                                <Typography variant="body1"
+                                <Typography variant="body2"
                                             color="text.secondary"
-                                            sx={{color: "snow"}}>
+                                            sx={{
+                                                color: "snow",
+                                                maxWidth: 250,
+                                                whiteSpace: 'nowrap', // Limit text to one line
+                                                overflow: 'hidden',   // Cut off text if too long
+                                                textOverflow: 'ellipsis', // ... Show when text is truncated
+                                            }}>
                                     {game.publisher}
                                 </Typography>
                             </Box>
@@ -60,8 +72,8 @@ export default function GameDetails(props: GameDetailProps) {
                              alt="Ohne Bild"
                              style={{
                                  objectFit: 'cover',
-                                 maxWidth: '700px',
-                                 maxHeight: '700px',
+                                 maxWidth: '1000px',
+                                 maxHeight: '1000px',
                                  width: '100%',
                                  height: '100%'
                              }}/>
@@ -74,9 +86,8 @@ export default function GameDetails(props: GameDetailProps) {
                                 maxWidth: 600,
                                 mx: "auto",
                                 color: "snow",
-                                whiteSpace: 'pre-line', // Zeilenumbrüche anzeigen
-                            }}
-                        >
+                                whiteSpace: 'pre-line', // Shows the line breaks (you should pay attention to Multiline/RichText)
+                            }}>
                             {game.note}
                         </Typography>
 


### PR DESCRIPTION
Added that the formatting in the notes is displayed in the GameDetails. 

It is now also not possible to display text that is too long in the publisher and genre. 
Text that is too long remains in one line and may be displayed with ... is displayed.

The complete text is always visible in editing mode to adjust or edit it.